### PR TITLE
Git config modifications

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -1,5 +1,6 @@
 [core]
   ignorecase = false
+  longpaths = true
 
 [alias]
   co = checkout
@@ -14,7 +15,7 @@
   lola = log --graph --decorate --pretty=oneline --abbrev-commit --all
   ls = ls-files
   com = checkout master
-  po = pull origin
+  po = !git pull origin || git pull origin
   stap = stash pop
   clfd = clean -f -d
   #clean branches (delete branches that have already been merged on to master)


### PR DESCRIPTION
Set git longpaths on to circumvent old windows filename limit
Set git po alias to execute twice if necessary in case credential cacheer has stale RSA credentials
